### PR TITLE
[+]增加支持递归查询某一个文件夹

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ optional arguments:
   -f format  customize naming format
   -o output  customize saving folder
   -d         delete source after conversion
-  -rs        recursive search folder
   -c         overwrite file with the same name
   -r         auto rename if file name conflicts
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ optional arguments:
   -f format  customize naming format
   -o output  customize saving folder
   -d         delete source after conversion
+  -rs        recursive search folder
   -c         overwrite file with the same name
   -r         auto rename if file name conflicts
 ```

--- a/ncmdump/app.py
+++ b/ncmdump/app.py
@@ -36,6 +36,10 @@ parser.add_argument(
     '-d', dest = 'delete', action = 'store_true',
     help = 'delete source after conversion'
 )
+parser.add_argument(
+    '-rs', dest = 'recursivesearch', action = 'store_true',
+    help = 'recursive search folder'
+)
 group = parser.add_mutually_exclusive_group()
 group.add_argument(
     '-c', dest = 'cover', action = 'store_true',
@@ -84,6 +88,17 @@ def name_format(path, meta):
     if args.rename: save = validate_collision(save)
     return save
 
+def search_ncms(path, list):
+    _fileNames = os.listdir(path)
+    for _file in _fileNames:
+        _tempPath = path + '/' + _file
+
+        if os.path.isfile(_tempPath):
+            if os.path.splitext(_tempPath)[1] == ".ncm":
+                list.append(_tempPath)
+        else:
+            search_ncms(_tempPath, list)
+
 def main():
     if args.output:
         args.output = os.path.abspath(args.output)
@@ -100,7 +115,10 @@ def main():
         if not os.path.exists(path):
             continue
         if os.path.isdir(path):
-            files += [os.path.join(path, name) for name in os.listdir(path) if os.path.splitext(name)[-1] == '.ncm']
+            if args.recursivesearch:
+                search_ncms(path, files)
+            else:
+                files += [os.path.join(path, name) for name in os.listdir(path) if os.path.splitext(name)[-1] == '.ncm']
         else:
             files += [path]
 

--- a/ncmdump/app.py
+++ b/ncmdump/app.py
@@ -36,10 +36,6 @@ parser.add_argument(
     '-d', dest = 'delete', action = 'store_true',
     help = 'delete source after conversion'
 )
-parser.add_argument(
-    '-rs', dest = 'recursivesearch', action = 'store_true',
-    help = 'recursive search folder'
-)
 group = parser.add_mutually_exclusive_group()
 group.add_argument(
     '-c', dest = 'cover', action = 'store_true',
@@ -89,15 +85,17 @@ def name_format(path, meta):
     return save
 
 def search_ncms(path, list):
-    _fileNames = os.listdir(path)
-    for _file in _fileNames:
-        _tempPath = path + '/' + _file
+    fileNames = os.listdir(path)
+    for filePath in fileNames:
+        tempPath = path + '/' + filePath
 
-        if os.path.isfile(_tempPath):
-            if os.path.splitext(_tempPath)[1] == ".ncm":
-                list.append(_tempPath)
+        if os.path.isfile(tempPath):
+            if os.path.splitext(tempPath)[1] == ".ncm":
+                tempPath = tempPath.replace("\\", "/")
+                if not tempPath in list:
+                    list.append(tempPath)
         else:
-            search_ncms(_tempPath, list)
+            search_ncms(tempPath, list)
 
 def main():
     if args.output:
@@ -115,12 +113,11 @@ def main():
         if not os.path.exists(path):
             continue
         if os.path.isdir(path):
-            if args.recursivesearch:
-                search_ncms(path, files)
-            else:
-                files += [os.path.join(path, name) for name in os.listdir(path) if os.path.splitext(name)[-1] == '.ncm']
+            search_ncms(path, files)
         else:
-            files += [path]
+            path = path.replace("\\", "/")
+            if not path in files:
+                files += [path]
 
     if sys.version[0] == '2':
         files = [path.decode(sys.stdin.encoding) for path in files]


### PR DESCRIPTION
云音乐下载音乐的时候可以选择按照歌唱家-专辑这种格式保存,这样保存后的文件夹就会有多层文件夹,使用-rs参数然后配合input传入一个文件夹路径,就可以直接递归整个文件夹路径.